### PR TITLE
Use dynamic route for fetching individual project

### DIFF
--- a/src/components/NonSSRWrapper.tsx
+++ b/src/components/NonSSRWrapper.tsx
@@ -1,0 +1,8 @@
+import dynamic from "next/dynamic";
+import React from "react";
+const NonSSRWrapper = (props: any) => (
+  <React.Fragment>{props.children}</React.Fragment>
+);
+export default dynamic(() => Promise.resolve(NonSSRWrapper), {
+  ssr: false,
+});

--- a/src/lib/google/sheets.ts
+++ b/src/lib/google/sheets.ts
@@ -11,6 +11,9 @@ const {
   sheets: { mainDatabase, pendingProjects },
 } = config.constants.google.sheets.databaseSheet;
 
+/**
+ * Use API route /api/project-data/[slug] to fetch cached single project
+ */
 export async function fetchSingleProjectData(slug: string) {
   const projectData = await fetchProjectData();
 

--- a/src/pages/api/project-data/[slug].ts
+++ b/src/pages/api/project-data/[slug].ts
@@ -1,11 +1,12 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type { NextApiRequest, NextApiResponse } from "next";
-import { fetchProjectData } from "@/lib/google";
+import { fetchSingleProjectData } from "@/lib/google";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<any>
 ) {
-  const projectData = await fetchProjectData();
+  const { slug } = req.query;
+  const projectData = await fetchSingleProjectData(slug as string);
   res.status(200).json({ data: projectData });
 }

--- a/src/pages/api/project-data/index.ts
+++ b/src/pages/api/project-data/index.ts
@@ -1,0 +1,12 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchProjectData } from "@/lib/google";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<any>
+) {
+  
+  const projectData = await fetchProjectData();
+  res.status(200).json({ data: projectData });
+}

--- a/src/pages/projects/[...slug].tsx
+++ b/src/pages/projects/[...slug].tsx
@@ -1,25 +1,42 @@
-import { GetServerSideProps } from "next";
-import { fetchSingleProjectData } from "@/lib/google";
-import Header from "@/templates/partials/Header";
-import Footer from "@/templates/partials/Footer";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  PreviewData,
+} from "next";
 import IndividualProjectPage from "../../templates/IndividualProjectPage";
+import { ParsedUrlQuery } from "querystring";
 
 function ProjectPage(props: { projectData: any }) {
   return <IndividualProjectPage {...props} />;
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { params, res } = context;
-  const { slug } = params as { slug: string[] };
-  const projectData = (await fetchSingleProjectData(slug[0])) || null;
+  const { res } = context;
+  const url = getProjectDataUrl(context);
+  const projectData = await fetch(url).then((res) => res.json());
 
   res.setHeader("Cache-Control", "public, s-maxage=10, stale-while-revalidate");
 
   return {
     props: {
-      projectData,
+      projectData: projectData.data,
     },
   };
 };
 
 export default ProjectPage;
+
+type Context = GetServerSidePropsContext<ParsedUrlQuery, PreviewData>;
+function getProjectDataUrl(context: Context) {
+  const { params, res, req } = context;
+  const { slug } = params as { slug: string[] };
+  const baseUrl = getBaseUrl(req);
+
+  // We hit this route because it returns only the individual project data
+  return `${baseUrl}/nextjs-app/api/project-data/${slug}`;
+}
+
+function getBaseUrl(req: any) {
+  const protocol = req.headers["x-forwarded-proto"] || "http";
+  return req ? `${protocol}://${req.headers.host}` : "";
+}

--- a/src/templates/IndividualProjectPage/index.tsx
+++ b/src/templates/IndividualProjectPage/index.tsx
@@ -5,6 +5,7 @@ import { withController } from "@/lib/withContoller";
 import { Project } from "@/types";
 import omit from "lodash/fp/omit";
 import ReactPlayer from "react-player";
+import NonSSRWrapper from "../../components/NonSSRWrapper";
 
 function useController(props: { projectData: Project }) {
   return props;
@@ -13,11 +14,14 @@ function IndividualProjectPageTemplate(
   props: ReturnType<typeof useController>
 ) {
   const { projectData } = props;
-  console.log(projectData);
+
   let shortDescription =
     projectData["description_short_value_proposition_in_a_tweet"];
-  shortDescription =
-    shortDescription[0].toUpperCase() + shortDescription.slice(1);
+
+  if (shortDescription) {
+    shortDescription =
+      shortDescription[0].toUpperCase() + shortDescription.slice(1);
+  }
 
   const additionalInfo = omit(
     [
@@ -53,7 +57,7 @@ function IndividualProjectPageTemplate(
               <span>{projectData["organization_type"]}</span>
             </div>
             <b>Subcategories: </b>
-            <span>{projectData["sub_categories"].join(", ")}</span>
+            <span>{projectData["sub_categories"]?.join(", ")}</span>
             <p>{shortDescription}</p>
           </div>
         </div>
@@ -65,7 +69,12 @@ function IndividualProjectPageTemplate(
             </div>
             <div className="flex-1">
               {projectData["video_url"] && (
-                <ReactPlayer className="mb-4" url={projectData["video_url"]} />
+                <NonSSRWrapper>
+                  <ReactPlayer
+                    className="mb-4"
+                    url={projectData["video_url"]}
+                  />
+                </NonSSRWrapper>
               )}
               <div className="rounded border p-5">
                 <h3 className="font-bold mb-2 mt-0">Additional Information</h3>


### PR DESCRIPTION
This allows us to cache only the individual project, which greatly reduces the amount of data that needs to be sent around